### PR TITLE
Adding due date and basic checklist support

### DIFF
--- a/lib/trollop/lib.py
+++ b/lib/trollop/lib.py
@@ -335,6 +335,7 @@ class Card(LazyTrello, Closable, Deletable, Labeled):
     checkItemStates = Field()
     desc = Field('desc')
     labels = Field("labels")
+    due = DateField("due")
 
     board = ObjectField('idBoard', 'Board')
     list = ObjectField('idList', 'List')
@@ -365,7 +366,7 @@ class Checklist(LazyTrello):
     _prefix = '/checklists/'
 
     checkItems = SubList('CheckItem')
-    name = Field()
+    name = Field('name')
     board = ObjectField('idBoard', 'Board')
     cards = SubList('Card')
 
@@ -379,7 +380,9 @@ class CheckItem(LazyTrello):
 
     _prefix = '/checkItems/'
 
-    name = Field()
+    due = DateField('due')
+    state = Field('state')
+    name = Field('name')
     pos = Field()
     type = Field()
 


### PR DESCRIPTION
These items allow OrgExtended to export a Trello board to a basic org file.
I am hoping to add other bits that allow me to update a Trello board from an org file. 

The org specific pieces live in OrgExtended but I would love it if the core Trello API can live in the Trello package and I simply build on top of the great Trello support you have already built in this package.